### PR TITLE
Suggested format changes

### DIFF
--- a/48.yaml
+++ b/48.yaml
@@ -1,9 +1,8 @@
-﻿courseId: 53 # COURSE NAME
-categoryId: 48 # CATEGORY NAME
-quizId: ~ # auto generated at spring side
+﻿categoryId: 48 # CATEGORY NAME
 name: test_quiz
 questions:
-  - questionId: 1 # must be filled to maintain the initial order of the questions, since the questions is implemented as set at SpringBoot
+  - questionId: ~
+    order: 1
     description: Multiple inheritance means
     choices:
       - one class inheriting from more super classes
@@ -15,7 +14,8 @@ questions:
       Inheritance is inheriting from one super class, therefore multiple
       inheritance is inheriting from more superclass
     correctChoice: 0
-  - questionId: 2
+  - questionId: ~
+    order: 2
     description: Multiple inheritance means
     choices:
       - one class inheriting from more super classes
@@ -27,7 +27,8 @@ questions:
       Inheritance is inheriting from one super class, therefore multiple
       inheritance is inheriting from more superclass
     correctChoice: 0
-  - questionId: 3
+  - questionId: ~
+    order: 3
     description: 'The default value of a static integer variable of a class in Java is:'
     choices:
       - '0'
@@ -37,7 +38,8 @@ questions:
     hint: hint not applicable to this question
     explanation: The correct choice is 0. Since this is defined by Java.
     correctChoice: 0
-  - questionId: 4
+  - questionId: ~
+    order: 4
     description: Which statement is not true in java language?
     choices:
       - A public member of a class can be accessed in all the packages.
@@ -51,7 +53,8 @@ questions:
       Private member of the same class can still be accessed by the methods in
       the same class
     correctChoice: 1
-  - questionId: 5
+  - questionId: ~
+    order: 5
     description: Which statement is not true in java language?
     choices:
       - A public member of a class can be accessed in all the packages.


### PR DESCRIPTION
I've made some exemplary changes to the data model.
I'm opening this pull request so we can discuss.

- removed the quiz id:
  I'd suggest to model the database in a way that the categoryId == quizId, so there's no need to additionally track the quizId in the yaml file.
- removed the course id:
  Unless we want to have different quizzes if a category is used in multiple courses, we don't need to have the course id.
  The category id is enough.
- removed the question id:
  The question id has to be *globally unique* in the database, so the knowledgeforge has to assign them.
  My suggestion would be to write them back into the yaml and commit the file automatically once the knowledgeforge has loaded a question that didn't have a questionId yet.
- added `order` to question:
  Since the id can't be used any more to keep track of the order, an extra order field could be used for that.

Should the knowledgeforge delete quizzes and questions that get deleted from this repository? 